### PR TITLE
Setting webpack jsonp function to avoid global variable collision.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
   output: {
     filename: "openmrs-esm-login.js",
     libraryTarget: "system",
-    path: path.resolve(__dirname, "dist")
+    path: path.resolve(__dirname, "dist"),
+    jsonpFunction: "webpackJsonp_openmrs_esm_login"
   },
   module: {
     rules: [


### PR DESCRIPTION
The [webpack jsonp function](https://webpack.js.org/configuration/output/#outputjsonpfunction) is the name of a global variable that webpack creates. Webpack uses this global variable to communicate between the main bundle and the code splits for that main bundle.

By default, the name of the global variable is `webpackJsonp`. The problem is that if you have multiple webpack bundles running in the same web app (which we definitely do at OpenMRS), that they will start overriding each other and you can run into situations where the order in which the bundles execute change code splits are associated with which main bundles. It's a very nasty bug that I've encountered at previous companies.

This PR solves the problem by naming the global variable something unique enough for it not to collide with any other.