### PR TITLE
Remove i18next-extract babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,13 +5,6 @@
     "@babel/preset-typescript"
   ],
   "plugins": [
-    "@babel/plugin-proposal-class-properties",
-    [
-      "i18next-extract",
-      {
-        "outputPath": "translations/{{locale}}.json",
-        "discardOldKeys": true
-      }
-    ]
+    "@babel/plugin-proposal-class-properties"
   ]
 }


### PR DESCRIPTION
The i18next-extract babel plugin causes Bamboo to fail with 
```
EEXIST: file already exists, mkdir 'translations'
```

This is the only module presently using it. It also has highly irregular behaviour, adding and removing parts of translation files in ways that seem non-deterministic.