### PR TITLE
Fix location select style for firefox

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -88,7 +88,7 @@
   background-color: var(--omrs-color-bg-high-contrast);
   list-style: none;
   display: grid;
-  grid-auto-columns: 21rem;
+  grid-auto-columns: 23rem;
   grid-auto-flow: column;
   grid-template-rows: repeat(20, min-content);
   margin-left: 0.5rem;


### PR DESCRIPTION
Firefox didn't like the CSS I wrote for chrome.

Firefox Before:
![Screenshot from 2020-03-26 12-10-52](https://user-images.githubusercontent.com/1031876/77686930-e781ba80-6f5a-11ea-8e74-de830e9a49a5.png)

Firefox After:
![Screenshot from 2020-03-26 12-10-30](https://user-images.githubusercontent.com/1031876/77686939-ebadd800-6f5a-11ea-80d1-7cd8a5533ff0.png)

Chrome Before:
![Screenshot from 2020-03-26 12-12-34](https://user-images.githubusercontent.com/1031876/77687045-1c8e0d00-6f5b-11ea-8729-4d5c657787a9.png)

Chrome After:
![Screenshot from 2020-03-26 12-12-08](https://user-images.githubusercontent.com/1031876/77687039-1861ef80-6f5b-11ea-9403-5018acc026af.png)
