### PR TITLE
Add manual mock to silence i18next test warnings

### DIFF
--- a/__mocks__/react-i18next.js
+++ b/__mocks__/react-i18next.js
@@ -1,0 +1,54 @@
+const React = require("react");
+const reactI18next = require("react-i18next");
+
+const hasChildren = (node) =>
+  node && (node.children || (node.props && node.props.children));
+
+const getChildren = (node) =>
+  node && node.children ? node.children : node.props && node.props.children;
+
+const renderNodes = (reactNodes) => {
+  if (typeof reactNodes === "string") {
+    return reactNodes;
+  }
+
+  return Object.keys(reactNodes).map((key, i) => {
+    const child = reactNodes[key];
+    const isElement = React.isValidElement(child);
+
+    if (typeof child === "string") {
+      return child;
+    }
+    if (hasChildren(child)) {
+      const inner = renderNodes(getChildren(child));
+      return React.cloneElement(child, { ...child.props, key: i }, inner);
+    }
+    if (typeof child === "object" && !isElement) {
+      return Object.keys(child).reduce(
+        (str, childKey) => `${str}${child[childKey]}`,
+        ""
+      );
+    }
+
+    return child;
+  });
+};
+
+const useMock = [(k) => k, {}];
+useMock.t = (k) => k;
+useMock.i18n = {};
+
+module.exports = {
+  // this mock makes sure any components using the translate HoC receive the t function as a prop
+  Trans: ({ children }) => renderNodes(children),
+  Translation: ({ children }) => children((k) => k, { i18n: {} }),
+  useTranslation: () => useMock,
+
+  // mock if needed
+  I18nextProvider: reactI18next.I18nextProvider,
+  initReactI18next: reactI18next.initReactI18next,
+  setDefaults: reactI18next.setDefaults,
+  getDefaults: reactI18next.getDefaults,
+  setI18n: reactI18next.setI18n,
+  getI18n: reactI18next.getI18n,
+};


### PR DESCRIPTION
Jest is warning about `useTranslation` about not having an `i18n` instance when running tests.

This PR introduces a manual mock for this. The mock is derived from the official [react-i18next](https://github.com/i18next/react-i18next/blob/master/example/v9.x.x/test-jest/__mocks__/react-i18next.js) repo.

i18next issue: https://github.com/i18next/react-i18next/issues/748

Before:
<img width="714" alt="Screenshot 2020-05-04 at 20 39 46" src="https://user-images.githubusercontent.com/8509731/80997914-bc886180-8e4a-11ea-9a9d-216e2957b0b1.png">

After:
<img width="707" alt="Screenshot 2020-05-04 at 21 23 34" src="https://user-images.githubusercontent.com/8509731/80999553-8a2c3380-8e4d-11ea-89cb-13b46618519b.png">
