### PR TITLE
Fix `update to Login was not wrapped in act(...)` warning

### DIFF
--- a/src/login/login.component.test.tsx
+++ b/src/login/login.component.test.tsx
@@ -53,7 +53,7 @@ describe(`<Login />`, () => {
     expect(wrapper.getByText("Login")).not.toHaveAttribute("disabled");
   });
 
-  it(`makes an API request when you submit the form`, () => {
+  it(`makes an API request when you submit the form`, async () => {
     mockedLogin.mockReturnValue(Promise.resolve({ some: "data" }));
     expect(performLogin).not.toHaveBeenCalled();
     fireEvent.change(wrapper.getByLabelText("Username"), {
@@ -63,6 +63,7 @@ describe(`<Login />`, () => {
       target: { value: "no-tax-fraud" },
     });
     fireEvent.click(wrapper.getByText("Login"));
+    await wait();
     expect(performLogin).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Fix "not wrapped in act(..)" warning by waiting for the mocked `mockedLogin` promise. 

Before:
<img width="800" alt="Screenshot 2020-05-04 at 22 16 52" src="https://user-images.githubusercontent.com/8509731/81005527-c2843f80-8e56-11ea-8d5f-e2c5d4b9a7d0.png">

After:
<img width="724" alt="Screenshot 2020-05-04 at 22 33 45" src="https://user-images.githubusercontent.com/8509731/81005943-6372fa80-8e57-11ea-838f-a32fe5f04f49.png">
