### PR TITLE
Add i18n key for `Powered by`

### DIFF
--- a/src/login/login.component.tsx
+++ b/src/login/login.component.tsx
@@ -199,7 +199,9 @@ export default function Login(props: LoginProps) {
         </form>
       </div>
       <div className="omrs-margin-top-32">
-        <p className={styles["powered-by-txt"]}>Powered by</p>
+        <p className={styles["powered-by-txt"]}>
+          <Trans i18nKey="poweredBy">Powered by</Trans>
+        </p>
         <div>
           <svg role="img" className={styles["powered-by-logo"]}>
             <use xlinkHref="#omrs-logo-partial-mono"></use>

--- a/translations/en.json
+++ b/translations/en.json
@@ -4,5 +4,6 @@
   "login": "Login",
   "password": "Password",
   "username": "Username",
-  "welcome": "Welcome"
+  "welcome": "Welcome",
+  "poweredBy": "Powered by"
 }


### PR DESCRIPTION
Default:

<img width="426" alt="Screenshot 2020-05-08 at 10 27 51" src="https://user-images.githubusercontent.com/8509731/81386701-1f654b80-911e-11ea-8438-b56e24a34b5b.png">

Spanish translation:

<img width="425" alt="Screenshot 2020-05-08 at 10 23 33" src="https://user-images.githubusercontent.com/8509731/81386709-23916900-911e-11ea-9b3d-501a37c6bcdb.png">
