### PR TITLE
Refactored to Fix Authentication Issue

### DIFF
--- a/__mocks__/openmrs-esm-module-config.mock.tsx
+++ b/__mocks__/openmrs-esm-module-config.mock.tsx
@@ -7,21 +7,23 @@ export const validators = {
   isString: jest.fn(),
 };
 
+export const config = {
+  chooseLocation: {
+    enabled: true,
+  },
+  logo: {
+    src: null,
+  },
+  links: {
+    loginSuccess: {
+      url: "/home",
+      spa: true,
+    },
+  },
+};
+
 export function useConfig() {
-  return {
-    chooseLocation: {
-      enabled: true,
-    },
-    logo: {
-      src: null,
-    },
-    links: {
-      loginSuccess: {
-        url: "/home",
-        spa: true,
-      },
-    },
-  };
+  return config;
 }
 
 export const ModuleNameContext = React.createContext("fake-module-config");

--- a/package-lock.json
+++ b/package-lock.json
@@ -4362,6 +4362,12 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
+      "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -4544,6 +4550,27 @@
       "integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.7.tgz",
+      "integrity": "sha512-2ouP76VQafKjtuc0ShpwUebhHwJo0G6rhahW9Pb8au3tQTjYXd2jta4wv6U2tGLR/I42yuG00+UXjNYY0dTzbg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+      "integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/source-list-map": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@testing-library/jest-dom": "^5.2.0",
     "@testing-library/react": "^9.5.0",
     "@types/jest": "^25.1.4",
+    "@types/react-router": "^5.1.7",
+    "@types/react-router-dom": "^5.1.5",
     "@typescript-eslint/parser": "^2.25.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.2.0",

--- a/src/choose-location/choose-location.component.test.tsx
+++ b/src/choose-location/choose-location.component.test.tsx
@@ -1,160 +1,57 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { act } from "react-dom/test-utils";
-import { cleanup, fireEvent, render, wait } from "@testing-library/react";
+import { cleanup, wait } from "@testing-library/react";
 import ChooseLocation from "./choose-location.component";
-import {
-  setSessionLocation,
-  searchLocationsFhir,
-} from "./choose-location.resource";
+import renderWithRouter from "../test-helpers/render-with-router";
 
-const historyMock = { push: jest.fn() };
-const mockedSetSessionLocation = setSessionLocation as jest.Mock;
-const mockSearch = searchLocationsFhir as jest.Mock;
-const loginLocations = {
-  data: {
-    entry: [
-      { resource: { id: "111", name: "Earth" } },
-      { resource: { id: "222", name: "Mars" } },
-    ],
-  },
-};
-let locationData = {
-  activeLocation: "",
-  locationResult: loginLocations,
-  emptyResult: false,
-};
 jest.mock("./choose-location.resource.ts", () => ({
-  searchLocationsFhir: jest.fn().mockResolvedValue({
-    data: {
-      entry: [],
-    },
-  }),
-  setSessionLocation: jest.fn().mockResolvedValue(null),
+  queryLocations: jest.fn(() =>
+    Promise.resolve([
+      {
+        resource: {
+          id: "abc",
+          name: "foo",
+        },
+      },
+    ])
+  ),
+  setSessionLocation: jest.fn(() => Promise.resolve()),
 }));
 
-jest.mock("lodash", () => ({
-  debounce: jest.fn((fn) => fn),
-  isEmpty: jest.fn((arr) => arr.length === 0),
+jest.mock("@openmrs/esm-api", () => ({
+  getCurrentUser: jest.fn(() => ({
+    subscribe(cb: (user: any) => void) {
+      cb({
+        display: "Demo",
+      });
+      return {
+        unsubscribe() {},
+      };
+    },
+  })),
 }));
 
 describe(`<ChooseLocation />`, () => {
-  let earthInput,
-    searchInput,
-    marsInput,
-    submitButton,
-    wrapper,
-    locationEntries;
-  beforeEach(async () => {
-    // reset mocks
-    locationEntries = loginLocations.data.entry;
-    historyMock.push.mockReset();
-    mockedSetSessionLocation.mockReset();
-    mockedSetSessionLocation.mockResolvedValue(null);
-    //prepare components
-    wrapper = render(
-      <ChooseLocation
-        history={historyMock as any}
-        location={undefined}
-        match={undefined}
-      />
-    );
-    searchInput = wrapper.container.querySelector("input");
-    submitButton = wrapper.getByText("Confirm", { selector: "button" });
-  });
-
   afterEach(cleanup);
-  it("trigger search on typing", async () => {
-    mockSearch.mockResolvedValue(loginLocations);
-    act(() => {
-      fireEvent.change(searchInput, { target: { value: "Mars" } });
-    });
-    await wait(() => {
-      expect(wrapper.getByText("Mars")).not.toBeNull();
-      expect(submitButton).toHaveAttribute("disabled");
-    });
-  });
 
-  it(`disables/enables the submit button when input is invalid/valid`, async () => {
-    act(() => {
-      fireEvent.change(searchInput, { target: { value: "Mars" } });
-    });
-    await wait(() => {
-      expect(wrapper.queryByText("Mars")).not.toBeNull();
-      marsInput = wrapper.getByLabelText("Mars");
-    });
-    act(() => {
-      fireEvent.click(marsInput);
-    });
-    await wait(() => {
-      expect(submitButton).not.toHaveAttribute("disabled");
-    });
-  });
-
-  it(`makes an API request when you submit the form`, async () => {
-    expect(setSessionLocation).not.toHaveBeenCalled();
-    act(() => {
-      fireEvent.change(searchInput, { target: { value: "Mars" } });
-    });
-    await wait(() => {
-      expect(wrapper.queryByText("Mars")).not.toBeNull();
-      marsInput = wrapper.getByLabelText("Mars");
-    });
-    fireEvent.click(marsInput);
-    fireEvent.click(submitButton);
-    await wait(() => expect(setSessionLocation).toHaveBeenCalled());
-  });
-
-  it(`send the user to the home page on submit`, async () => {
-    expect(setSessionLocation).not.toHaveBeenCalled();
-    act(() => {
-      fireEvent.change(searchInput, { target: { value: "Mars" } });
-    });
-    await wait(() => {
-      expect(wrapper.queryByText("Mars")).not.toBeNull();
-      marsInput = wrapper.getByLabelText("Mars");
-    });
-    fireEvent.click(marsInput);
-    fireEvent.click(submitButton);
-    await wait(() => {
-      expect(historyMock.push.mock.calls.length).toBe(1);
-      expect(historyMock.push.mock.calls[0][0]).toBe("/home");
-    });
-  });
-
-  it(`send the user to the redirect page on submit`, async () => {
-    cleanup();
-    mockSearch.mockResolvedValue(loginLocations);
-
+  it(`should redirect back to referring page on successful login when there is only one location`, async () => {
     const locationMock = {
       state: {
         referrer: "/home/patient-search",
       },
     };
-    wrapper = render(
-      <ChooseLocation
-        history={historyMock as any}
-        location={locationMock as any}
-        match={undefined}
-      />
-    );
-    searchInput = wrapper.container.querySelector("input");
-    act(() => {
-      fireEvent.change(searchInput, { target: { value: "Mars" } });
+    cleanup();
+    const wrapper = renderWithRouter(ChooseLocation, {
+      location: locationMock,
     });
-    await wait(() => {
-      expect(wrapper.queryByText("Mars")).not.toBeNull();
-      marsInput = wrapper.getByLabelText("Mars");
-    });
-    submitButton = wrapper.getByText("Confirm", { selector: "button" });
-    expect(setSessionLocation).not.toHaveBeenCalled();
-    fireEvent.click(marsInput);
-    fireEvent.click(submitButton);
-    await wait(() => {
-      expect(historyMock.push.mock.calls.length).toBe(1);
-      expect(historyMock.push.mock.calls[0][0]).toBe(
-        locationMock.state.referrer
-      );
-    });
+    await act(wait);
+    expect(wrapper.history.location.pathname).toBe(locationMock.state.referrer);
+  });
+
+  it(`should set location and skip location select page if there is exactly one location`, async () => {
+    cleanup();
+    const wrapper = renderWithRouter(ChooseLocation, {});
+    await act(wait);
+    expect(wrapper.history.location.pathname).toBe("/home");
   });
 });

--- a/src/choose-location/choose-location.component.test.tsx
+++ b/src/choose-location/choose-location.component.test.tsx
@@ -1,14 +1,12 @@
 import "@testing-library/jest-dom";
 import React from "react";
-import { of } from "rxjs";
+import { act } from "react-dom/test-utils";
 import { cleanup, fireEvent, render, wait } from "@testing-library/react";
 import ChooseLocation from "./choose-location.component";
 import {
-  getLoginLocations,
   setSessionLocation,
   searchLocationsFhir,
 } from "./choose-location.resource";
-import { act } from "react-dom/test-utils";
 
 const historyMock = { push: jest.fn() };
 const mockedSetSessionLocation = setSessionLocation as jest.Mock;
@@ -55,7 +53,11 @@ describe(`<ChooseLocation />`, () => {
     mockedSetSessionLocation.mockResolvedValue(null);
     //prepare components
     wrapper = render(
-      <ChooseLocation history={historyMock} loginLocations={locationEntries} />
+      <ChooseLocation
+        history={historyMock as any}
+        location={undefined}
+        match={undefined}
+      />
     );
     searchInput = wrapper.container.querySelector("input");
     submitButton = wrapper.getByText("Confirm", { selector: "button" });
@@ -131,9 +133,9 @@ describe(`<ChooseLocation />`, () => {
     };
     wrapper = render(
       <ChooseLocation
-        history={historyMock}
-        loginLocations={locationEntries}
-        location={locationMock}
+        history={historyMock as any}
+        location={locationMock as any}
+        match={undefined}
       />
     );
     searchInput = wrapper.container.querySelector("input");

--- a/src/choose-location/choose-location.component.test.tsx
+++ b/src/choose-location/choose-location.component.test.tsx
@@ -1,8 +1,11 @@
 import "@testing-library/jest-dom";
 import { act } from "react-dom/test-utils";
 import { cleanup, wait } from "@testing-library/react";
+import { queryLocations } from "./choose-location.resource";
 import ChooseLocation from "./choose-location.component";
 import renderWithRouter from "../test-helpers/render-with-router";
+
+const { config } = require("@openmrs/esm-module-config");
 
 jest.mock("./choose-location.resource.ts", () => ({
   queryLocations: jest.fn(() =>
@@ -53,5 +56,68 @@ describe(`<ChooseLocation />`, () => {
     const wrapper = renderWithRouter(ChooseLocation, {});
     await act(wait);
     expect(wrapper.history.location.pathname).toBe("/home");
+  });
+
+  it(`should set location and skip location select page if there is no location`, async () => {
+    cleanup();
+    (queryLocations as any).mockImplementationOnce(() => Promise.resolve([]));
+    const wrapper = renderWithRouter(ChooseLocation, {});
+    await act(wait);
+    expect(wrapper.history.location.pathname).toBe("/home");
+  });
+
+  it(`should show the location picker when multiple locations exist`, async () => {
+    cleanup();
+    (queryLocations as any).mockImplementationOnce(() =>
+      Promise.resolve([
+        {
+          resource: {
+            id: "abc",
+            name: "foo",
+          },
+        },
+        {
+          resource: {
+            id: "def",
+            name: "ghi",
+          },
+        },
+      ])
+    );
+    const wrapper = renderWithRouter(ChooseLocation, {});
+    await act(wait);
+    expect(wrapper.history.location.pathname).toBe("/");
+  });
+
+  it(`should not show the location picker when disabled`, async () => {
+    cleanup();
+    config.chooseLocation.enabled = false;
+    (queryLocations as any).mockImplementationOnce(() =>
+      Promise.resolve([
+        {
+          resource: {
+            id: "abc",
+            name: "foo",
+          },
+        },
+        {
+          resource: {
+            id: "def",
+            name: "ghi",
+          },
+        },
+      ])
+    );
+    const wrapper = renderWithRouter(ChooseLocation, {});
+    await act(wait);
+    expect(wrapper.history.location.pathname).toBe("/home");
+  });
+
+  it(`should redirect to custom path if configured`, async () => {
+    cleanup();
+    config.links.loginSuccess.url = "/foo";
+    const wrapper = renderWithRouter(ChooseLocation, {});
+    await act(wait);
+    expect(wrapper.history.location.pathname).toBe("/foo");
   });
 });

--- a/src/choose-location/choose-location.component.tsx
+++ b/src/choose-location/choose-location.component.tsx
@@ -23,7 +23,7 @@ export default function ChooseLocation(props: ChooseLocationProps) {
     Array<LocationEntry>
   >(null);
   const [currentUser, setCurrentUser] = React.useState(null);
-  const [loading, setLoading] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(true);
 
   const changeLocation = React.useCallback(
     (locationUuid?: string) => {
@@ -51,7 +51,9 @@ export default function ChooseLocation(props: ChooseLocationProps) {
   React.useEffect(() => {
     const ac = new AbortController();
     const sub = getCurrentUser().subscribe((user) => {
-      setCurrentUser(user ? user.display : currentUser);
+      if (user) {
+        setCurrentUser(user.display);
+      }
     }, createErrorHandler());
 
     queryLocations("", ac).then(
@@ -70,12 +72,12 @@ export default function ChooseLocation(props: ChooseLocationProps) {
       if (!config.chooseLocation.enabled || loginLocations.length < 2) {
         changeLocation(loginLocations[0]?.resource.id);
       } else {
-        setLoading(false);
+        setIsLoading(false);
       }
     }
-  }, [loginLocations, currentUser]);
+  }, [loginLocations, currentUser, changeLocation]);
 
-  if (!loading) {
+  if (!isLoading) {
     return (
       <LocationPicker
         currentUser={currentUser}

--- a/src/choose-location/choose-location.component.tsx
+++ b/src/choose-location/choose-location.component.tsx
@@ -1,18 +1,12 @@
 import React from "react";
-import { always } from "kremling";
-import { useConfig } from "@openmrs/esm-module-config";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { getCurrentUser } from "@openmrs/esm-api";
-import { Trans } from "react-i18next";
-import {
-  setSessionLocation,
-  searchLocationsFhir,
-  LocationEntry,
-} from "./choose-location.resource";
-import navigate from "../navigate";
-import styles from "../styles.css";
-import { debounce, isEmpty } from "lodash";
 import { RouteComponentProps, StaticContext } from "react-router";
+import { useConfig } from "@openmrs/esm-module-config";
+import { getCurrentUser } from "@openmrs/esm-api";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import { setSessionLocation, queryLocations } from "./choose-location.resource";
+import { LocationEntry } from "../types";
+import LocationPicker from "../location-picker/location-picker.component";
+import navigate from "../navigate";
 
 interface LoginReferrer {
   referrer?: string;
@@ -22,245 +16,75 @@ interface ChooseLocationProps
   extends RouteComponentProps<{}, StaticContext, LoginReferrer> {}
 
 export default function ChooseLocation(props: ChooseLocationProps) {
+  const referrer = props.location?.state?.referrer;
+  
   const config = useConfig();
   const [loginLocations, setLoginLocations] = React.useState<
     Array<LocationEntry>
-  >(undefined);
+  >(null);
+  const [currentUser, setCurrentUser] = React.useState(null);
   const [loading, setLoading] = React.useState(true);
 
-  const changeLocation = (locationUuid?: string) => {
-    const sessionDefined = locationUuid
-      ? setSessionLocation(locationUuid, new AbortController())
-      : Promise.resolve();
+  const changeLocation = React.useCallback(
+    (locationUuid?: string) => {
+      const sessionDefined = locationUuid
+        ? setSessionLocation(locationUuid, new AbortController())
+        : Promise.resolve();
 
-    sessionDefined
-      .then(() => {
-        if (props.location?.state?.referrer) {
-          props.history.push(props.location.state.referrer);
-        } else {
-          navigate(
-            props,
-            config.links.loginSuccess.spa,
-            config.links.loginSuccess.url
-          );
-        }
-      })
-      .catch(createErrorHandler());
-  };
+      sessionDefined
+        .then(() => {
+          if (referrer) {
+            props.history.push(referrer);
+          } else {
+            navigate(
+              props,
+              config.links.loginSuccess.spa,
+              config.links.loginSuccess.url
+            );
+          }
+        })
+        .catch(createErrorHandler());
+    },
+    [referrer]
+  );
 
   React.useEffect(() => {
     const ac = new AbortController();
+    const sub = getCurrentUser().subscribe((user) => {
+      setCurrentUser(user ? user.display : currentUser);
+    }, createErrorHandler());
 
-    searchLocationsFhir("").then(
-      (locations) => setLoginLocations(locations.data.entry),
+    queryLocations('', ac).then(
+      (locations) => setLoginLocations(locations),
       createErrorHandler()
     );
 
-    return () => ac.abort();
+    return () => {
+      ac.abort();
+      sub.unsubscribe();
+    };
   }, []);
 
   React.useEffect(() => {
-    if (loginLocations) {
-      if (!config.chooseLocation.enabled || loginLocations.length < 1) {
+    if (loginLocations && currentUser) {
+      if (!config.chooseLocation.enabled || loginLocations.length < 2) {
         changeLocation(loginLocations[0]?.resource.id);
       } else {
         setLoading(false);
       }
     }
-  }, [loginLocations]);
+  }, [loginLocations, currentUser]);
 
   if (!loading) {
     return (
       <LocationPicker
+        currentUser={currentUser}
         loginLocations={loginLocations}
         onChangeLocation={changeLocation}
+        searchLocations={queryLocations}
       />
     );
   }
 
   return <div>Loading ...</div>;
 }
-
-interface LocationPickerProps {
-  loginLocations: Array<LocationEntry>;
-  onChangeLocation(locationUuid: string): void;
-}
-
-interface LocationDataState {
-  activeLocation: string;
-  locationResult: Array<LocationEntry>;
-}
-
-const LocationPicker: React.FC<LocationPickerProps> = (props) => {
-  const [locationData, setLocationData] = React.useState<LocationDataState>({
-    activeLocation: "",
-    locationResult: props.loginLocations,
-  });
-  const [searchTerm, setSearchTerm] = React.useState("");
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
-  const [currentUser, setCurrentUser] = React.useState(null);
-
-  const searchTimeout = 300;
-
-  React.useEffect(() => {
-    getCurrentUser().subscribe((user) => {
-      setCurrentUser(user ? user.display : currentUser);
-    }, createErrorHandler());
-  });
-
-  React.useEffect(() => {
-    const ac = new AbortController();
-
-    if (isSubmitting) {
-      props.onChangeLocation(locationData.activeLocation);
-    }
-
-    return () => ac.abort();
-  }, [isSubmitting]);
-
-  React.useEffect(() => {
-    const ac = new AbortController();
-
-    if (props.loginLocations.length > 100) {
-      if (searchTerm) {
-        searchLocationsFhir(searchTerm).then((locs) => {
-          changeLocationData({
-            locationResult: locs.data.entry,
-          });
-        }, createErrorHandler());
-      }
-    } else if (searchTerm) {
-      filterList(searchTerm);
-    } else if (props.loginLocations !== locationData.locationResult) {
-      changeLocationData({ locationResult: props.loginLocations });
-    }
-
-    return () => ac.abort();
-  }, [searchTerm, props.loginLocations]);
-
-  const search = debounce(
-    (location: string) => setSearchTerm(location),
-    searchTimeout
-  );
-
-  const filterList = (searchTerm: string) => {
-    if (searchTerm) {
-      const updatedList = props.loginLocations.filter((item) => {
-        return (
-          item.resource.name.toLowerCase().search(searchTerm.toLowerCase()) !==
-          -1
-        );
-      });
-
-      changeLocationData({ locationResult: updatedList });
-    }
-  };
-
-  const changeLocationData = (data: Partial<LocationDataState>) => {
-    if (data) {
-      setLocationData((prevState) => ({
-        ...prevState,
-        ...data,
-      }));
-    }
-  };
-
-  const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
-    evt.preventDefault();
-    setIsSubmitting(true);
-  };
-
-  return (
-    <div className={`canvas ${styles["container"]}`}>
-      <h1 className={styles["welcome-msg"]}>
-        <Trans i18nKey="welcome">Welcome</Trans> {currentUser}
-      </h1>
-      <form onSubmit={handleSubmit}>
-        <div className={`${styles["location-card"]} omrs-card`}>
-          <CardHeader>
-            <Trans i18nKey="location">Location</Trans>
-          </CardHeader>
-          <div className="omrs-input-group omrs-padding-12">
-            <input
-              className="omrs-input-underlined"
-              placeholder="Search for location"
-              aria-label="Search for location"
-              onChange={($event) => search($event.target.value)}
-            />
-          </div>
-          {!isEmpty(locationData.locationResult) && (
-            <div className={styles["location-radio-group"]}>
-              {locationData.locationResult.map((entry) => (
-                <RadioInput
-                  key={entry.resource.id}
-                  current={locationData.activeLocation}
-                  option={entry}
-                  changeLocationData={changeLocationData}
-                />
-              ))}
-            </div>
-          )}
-          {locationData.locationResult.length === 0 && (
-            <p className="omrs-type-body-regular omrs-padding-8">
-              <Trans i18nKey="locationNotFound">
-                Sorry, no location has been found
-              </Trans>
-            </p>
-          )}
-          <div className={styles["center"]}>
-            <p className={styles["error-msg"]} />
-          </div>
-        </div>
-        <div className={styles["center"]}>
-          <button
-            className={always(
-              `omrs-margin-16 omrs-btn omrs-rounded ${styles["location-submit-btn"]}`
-            ).toggle(
-              "omrs-filled-disabled",
-              "omrs-filled-action",
-              !locationData.activeLocation
-            )}
-            type="submit"
-            disabled={!locationData.activeLocation}
-          >
-            <Trans i18nKey="confirm">Confirm</Trans>
-          </button>
-        </div>
-      </form>
-    </div>
-  );
-};
-
-const CardHeader: React.FC = (props) => (
-  <div className={styles["card-header"]}>
-    <h2 className={`omrs-margin-8 omrs-margin-left-12`}>{props.children}</h2>
-  </div>
-);
-
-interface RadioInputProps {
-  option: LocationEntry;
-  current: string;
-  changeLocationData: (data: Partial<LocationDataState>) => void;
-}
-
-const RadioInput: React.FC<RadioInputProps> = ({
-  option,
-  current,
-  changeLocationData,
-}) => (
-  <div className="omrs-radio-button">
-    <input
-      id={option.resource.id}
-      type="radio"
-      name="location"
-      value={option.resource.id}
-      checked={current === option.resource.id}
-      onChange={(evt) =>
-        changeLocationData({ activeLocation: evt.target.value })
-      }
-    />
-    <label htmlFor={option.resource.id} className="omrs-padding-4">
-      {option.resource.name}
-    </label>
-  </div>
-);

--- a/src/choose-location/choose-location.component.tsx
+++ b/src/choose-location/choose-location.component.tsx
@@ -17,7 +17,7 @@ interface ChooseLocationProps
 
 export default function ChooseLocation(props: ChooseLocationProps) {
   const referrer = props.location?.state?.referrer;
-  
+
   const config = useConfig();
   const [loginLocations, setLoginLocations] = React.useState<
     Array<LocationEntry>
@@ -54,7 +54,7 @@ export default function ChooseLocation(props: ChooseLocationProps) {
       setCurrentUser(user ? user.display : currentUser);
     }, createErrorHandler());
 
-    queryLocations('', ac).then(
+    queryLocations("", ac).then(
       (locations) => setLoginLocations(locations),
       createErrorHandler()
     );

--- a/src/choose-location/choose-location.resource.ts
+++ b/src/choose-location/choose-location.resource.ts
@@ -1,5 +1,6 @@
 import { openmrsFetch, openmrsObservableFetch } from "@openmrs/esm-api";
 import { map } from "rxjs/operators";
+import { LocationResponse } from "../types";
 
 export function getLoginLocations(): Observable<Object[]> {
   return openmrsObservableFetch(
@@ -21,41 +22,21 @@ export function setSessionLocation(
   });
 }
 
-export interface LocationResponse {
-  type: string;
-  total: number;
-  resourceType: string;
-  meta: {
-    lastUpdated: string;
-  };
-  link: Array<{
-    relation: string;
-    url: string;
-  }>;
-  id: string;
-  entry: Array<LocationEntry>;
-}
-
-export interface LocationEntry {
-  resource: Resource;
-}
-
-export interface Resource {
-  id: string;
-  name: string;
-  resourceType: string;
-  status: "active" | "inactive";
-  meta?: {
-    tag?: Array<{
-      code: string;
-      display: string;
-      system: string;
-    }>;
-  };
-}
-
-export function searchLocationsFhir(location: string) {
+export function searchLocationsFhir(
+  location: string,
+  abortController: AbortController
+) {
   return openmrsFetch<LocationResponse>(`/ws/fhir2/Location?name=${location}`, {
     method: "GET",
+    signal: abortController.signal,
   });
+}
+
+export function queryLocations(
+  location: string,
+  abortController = new AbortController()
+) {
+  return searchLocationsFhir(location, abortController).then(
+    (locs) => locs.data.entry
+  );
 }

--- a/src/choose-location/choose-location.resource.ts
+++ b/src/choose-location/choose-location.resource.ts
@@ -20,8 +20,42 @@ export function setSessionLocation(
     signal: abortController.signal,
   });
 }
+
+export interface LocationResponse {
+  type: string;
+  total: number;
+  resourceType: string;
+  meta: {
+    lastUpdated: string;
+  };
+  link: Array<{
+    relation: string;
+    url: string;
+  }>;
+  id: string;
+  entry: Array<LocationEntry>;
+}
+
+export interface LocationEntry {
+  resource: Resource;
+}
+
+export interface Resource {
+  id: string;
+  name: string;
+  resourceType: string;
+  status: "active" | "inactive";
+  meta?: {
+    tag?: Array<{
+      code: string;
+      display: string;
+      system: string;
+    }>;
+  };
+}
+
 export function searchLocationsFhir(location: string) {
-  return openmrsFetch(`/ws/fhir2/Location?name=${location}`, {
+  return openmrsFetch<LocationResponse>(`/ws/fhir2/Location?name=${location}`, {
     method: "GET",
   });
 }

--- a/src/location-picker/location-picker.component.test.tsx
+++ b/src/location-picker/location-picker.component.test.tsx
@@ -19,7 +19,13 @@ jest.mock("lodash", () => ({
 }));
 
 describe(`<LocationPicker />`, () => {
-  let searchInput, marsInput, submitButton, wrapper, locationEntries, onChangeLocation, searchLocations;
+  let searchInput,
+    marsInput,
+    submitButton,
+    wrapper,
+    locationEntries,
+    onChangeLocation,
+    searchLocations;
 
   beforeEach(async () => {
     // reset mocks

--- a/src/location-picker/location-picker.component.test.tsx
+++ b/src/location-picker/location-picker.component.test.tsx
@@ -1,0 +1,135 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import { cleanup, fireEvent, render, wait } from "@testing-library/react";
+import LocationPicker from "./location-picker.component";
+
+const loginLocations = {
+  data: {
+    entry: [
+      { resource: { id: "111", name: "Earth" } },
+      { resource: { id: "222", name: "Mars" } },
+    ],
+  },
+};
+
+jest.mock("lodash", () => ({
+  debounce: jest.fn((fn) => fn),
+  isEmpty: jest.fn((arr) => arr.length === 0),
+}));
+
+describe(`<LocationPicker />`, () => {
+  let searchInput, marsInput, submitButton, wrapper, locationEntries, onChangeLocation, searchLocations;
+
+  beforeEach(async () => {
+    // reset mocks
+    locationEntries = loginLocations.data.entry;
+    onChangeLocation = jest.fn(() => {});
+    searchLocations = jest.fn(() => Promise.resolve([]));
+
+    //prepare components
+    wrapper = render(
+      <LocationPicker
+        loginLocations={locationEntries}
+        onChangeLocation={onChangeLocation}
+        searchLocations={searchLocations}
+        currentUser=""
+      />
+    );
+
+    searchInput = wrapper.container.querySelector("input");
+    submitButton = wrapper.getByText("Confirm", { selector: "button" });
+  });
+
+  afterEach(cleanup);
+
+  it("trigger search on typing", async () => {
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "Mars" } });
+    });
+
+    await wait(() => {
+      expect(wrapper.getByText("Mars")).not.toBeNull();
+      expect(submitButton).toHaveAttribute("disabled");
+    });
+  });
+
+  it(`disables/enables the submit button when input is invalid/valid`, async () => {
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "Mars" } });
+    });
+
+    await wait(() => {
+      expect(wrapper.queryByText("Mars")).not.toBeNull();
+      marsInput = wrapper.getByLabelText("Mars");
+    });
+
+    act(() => {
+      fireEvent.click(marsInput);
+    });
+
+    await wait(() => {
+      expect(submitButton).not.toHaveAttribute("disabled");
+    });
+  });
+
+  it(`makes an API request when you submit the form`, async () => {
+    expect(onChangeLocation).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "Mars" } });
+    });
+
+    await wait(() => {
+      expect(wrapper.queryByText("Mars")).not.toBeNull();
+      marsInput = wrapper.getByLabelText("Mars");
+    });
+
+    fireEvent.click(marsInput);
+    fireEvent.click(submitButton);
+
+    await wait(() => expect(onChangeLocation).toHaveBeenCalled());
+  });
+
+  it(`send the user to the home page on submit`, async () => {
+    expect(onChangeLocation).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "Mars" } });
+    });
+
+    await wait(() => {
+      expect(wrapper.queryByText("Mars")).not.toBeNull();
+      marsInput = wrapper.getByLabelText("Mars");
+    });
+
+    fireEvent.click(marsInput);
+    fireEvent.click(submitButton);
+
+    await wait(() => {
+      expect(onChangeLocation).toHaveBeenCalled();
+    });
+  });
+
+  it(`send the user to the redirect page on submit`, async () => {
+    expect(onChangeLocation).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "Mars" } });
+    });
+
+    await wait(() => {
+      expect(wrapper.queryByText("Mars")).not.toBeNull();
+      marsInput = wrapper.getByLabelText("Mars");
+    });
+
+    submitButton = wrapper.getByText("Confirm", { selector: "button" });
+
+    fireEvent.click(marsInput);
+    fireEvent.click(submitButton);
+
+    await wait(() => {
+      expect(onChangeLocation).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/location-picker/location-picker.component.tsx
+++ b/src/location-picker/location-picker.component.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { always } from "kremling";
+import { debounce, isEmpty } from "lodash";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import { Trans } from "react-i18next";
+import { LocationEntry } from "../types";
+import styles from "../styles.css";
+
+const CardHeader: React.FC = (props) => (
+  <div className={styles["card-header"]}>
+    <h2 className={`omrs-margin-8 omrs-margin-left-12`}>{props.children}</h2>
+  </div>
+);
+
+interface RadioInputProps {
+  option: LocationEntry;
+  current: string;
+  changeLocationData: (data: Partial<LocationDataState>) => void;
+}
+
+const RadioInput: React.FC<RadioInputProps> = ({
+  option,
+  current,
+  changeLocationData,
+}) => (
+  <div className="omrs-radio-button">
+    <input
+      id={option.resource.id}
+      type="radio"
+      name="location"
+      value={option.resource.id}
+      checked={current === option.resource.id}
+      onChange={(evt) =>
+        changeLocationData({ activeLocation: evt.target.value })
+      }
+    />
+    <label htmlFor={option.resource.id} className="omrs-padding-4">
+      {option.resource.name}
+    </label>
+  </div>
+);
+
+interface LocationDataState {
+  activeLocation: string;
+  locationResult: Array<LocationEntry>;
+}
+
+interface LocationPickerProps {
+  currentUser: string;
+  loginLocations: Array<LocationEntry>;
+  onChangeLocation(locationUuid: string): void;
+  searchLocations(query: string): Promise<Array<LocationEntry>>;
+}
+
+export default function LocationPicker(props: LocationPickerProps) {
+  const [locationData, setLocationData] = React.useState<LocationDataState>({
+    activeLocation: "",
+    locationResult: props.loginLocations,
+  });
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const searchTimeout = 300;
+
+  React.useEffect(() => {
+    if (isSubmitting) {
+      props.onChangeLocation(locationData.activeLocation);
+    }
+  }, [isSubmitting, locationData]);
+
+  React.useEffect(() => {
+    const ac = new AbortController();
+
+    if (props.loginLocations.length > 100) {
+      if (searchTerm) {
+        props.searchLocations(searchTerm).then((locationResult) => {
+          changeLocationData({
+            locationResult,
+          });
+        }, createErrorHandler());
+      }
+    } else if (searchTerm) {
+      filterList(searchTerm);
+    } else if (props.loginLocations !== locationData.locationResult) {
+      changeLocationData({ locationResult: props.loginLocations });
+    }
+
+    return () => ac.abort();
+  }, [searchTerm, props.loginLocations]);
+
+  const search = debounce(
+    (location: string) => setSearchTerm(location),
+    searchTimeout
+  );
+
+  const filterList = (searchTerm: string) => {
+    if (searchTerm) {
+      const updatedList = props.loginLocations.filter((item) => {
+        return (
+          item.resource.name.toLowerCase().search(searchTerm.toLowerCase()) !==
+          -1
+        );
+      });
+
+      changeLocationData({ locationResult: updatedList });
+    }
+  };
+
+  const changeLocationData = (data: Partial<LocationDataState>) => {
+    if (data) {
+      setLocationData((prevState) => ({
+        ...prevState,
+        ...data,
+      }));
+    }
+  };
+
+  const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    setIsSubmitting(true);
+  };
+
+  return (
+    <div className={`canvas ${styles["container"]}`}>
+      <h1 className={styles["welcome-msg"]}>
+        <Trans i18nKey="welcome">Welcome</Trans> {props.currentUser}
+      </h1>
+      <form onSubmit={handleSubmit}>
+        <div className={`${styles["location-card"]} omrs-card`}>
+          <CardHeader>
+            <Trans i18nKey="location">Location</Trans>
+          </CardHeader>
+          <div className="omrs-input-group omrs-padding-12">
+            <input
+              className="omrs-input-underlined"
+              placeholder="Search for location"
+              aria-label="Search for location"
+              onChange={(ev) => search(ev.target.value)}
+            />
+          </div>
+          {!isEmpty(locationData.locationResult) && (
+            <div className={styles["location-radio-group"]}>
+              {locationData.locationResult.map((entry) => (
+                <RadioInput
+                  key={entry.resource.id}
+                  current={locationData.activeLocation}
+                  option={entry}
+                  changeLocationData={changeLocationData}
+                />
+              ))}
+            </div>
+          )}
+          {locationData.locationResult.length === 0 && (
+            <p className="omrs-type-body-regular omrs-padding-8">
+              <Trans i18nKey="locationNotFound">
+                Sorry, no location has been found
+              </Trans>
+            </p>
+          )}
+          <div className={styles["center"]}>
+            <p className={styles["error-msg"]} />
+          </div>
+        </div>
+        <div className={styles["center"]}>
+          <button
+            className={always(
+              `omrs-margin-16 omrs-btn omrs-rounded ${styles["location-submit-btn"]}`
+            ).toggle(
+              "omrs-filled-disabled",
+              "omrs-filled-action",
+              !locationData.activeLocation
+            )}
+            type="submit"
+            disabled={!locationData.activeLocation}
+          >
+            <Trans i18nKey="confirm">Confirm</Trans>
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/login/login.component.test.tsx
+++ b/src/login/login.component.test.tsx
@@ -81,48 +81,4 @@ describe(`<Login />`, () => {
     await wait();
     expect(wrapper.history.location.pathname).toBe("/login/location");
   });
-
-  it(`should set location and skip location select page if there is exactly one location`, async () => {
-    cleanup();
-    wrapper = renderWithRouter(Login, { loginLocations: [loginLocations[0]] });
-    expect(setSessionLocation).not.toHaveBeenCalled();
-    mockedLogin.mockReturnValue(
-      Promise.resolve({ data: { authenticated: true } })
-    );
-    fireEvent.change(wrapper.getByLabelText("Username"), {
-      target: { value: "yoshi" },
-    });
-    fireEvent.change(wrapper.getByLabelText("Password"), {
-      target: { value: "no-tax-fraud" },
-    });
-    fireEvent.click(wrapper.getByText("Login"));
-    await wait();
-    expect(wrapper.history.location.pathname).toBe("/home");
-  });
-
-  it(`should redirect back to referring page on successful login when there is only one location`, async () => {
-    const locationMock = {
-      state: {
-        referrer: "/home/patient-search",
-      },
-    };
-    cleanup();
-    wrapper = renderWithRouter(Login, {
-      loginLocations: [loginLocations[0]],
-      location: locationMock,
-    });
-    expect(setSessionLocation).not.toHaveBeenCalled();
-    mockedLogin.mockReturnValue(
-      Promise.resolve({ data: { authenticated: true } })
-    );
-    fireEvent.change(wrapper.getByLabelText("Username"), {
-      target: { value: "yoshi" },
-    });
-    fireEvent.change(wrapper.getByLabelText("Password"), {
-      target: { value: "no-tax-fraud" },
-    });
-    fireEvent.click(wrapper.getByText("Login"));
-    await wait();
-    expect(wrapper.history.location.pathname).toBe(locationMock.state.referrer);
-  });
 });

--- a/src/login/login.component.test.tsx
+++ b/src/login/login.component.test.tsx
@@ -1,14 +1,9 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import Login from "./login.component";
+import { cleanup, fireEvent, wait } from "@testing-library/react";
 import { performLogin } from "./login.resource";
 import { setSessionLocation } from "../choose-location/choose-location.resource";
-import { cleanup, fireEvent, wait } from "@testing-library/react";
 import renderWithRouter from "../test-helpers/render-with-router";
-
-const historyMock = {
-  push: jest.fn().mockImplementationOnce((location) => location),
-};
 
 const mockedLogin = performLogin as jest.Mock;
 jest.mock("./login.resource", () => ({

--- a/src/login/login.component.tsx
+++ b/src/login/login.component.tsx
@@ -62,6 +62,7 @@ export default function Login(props: LoginProps) {
       try {
         const loginRes = await performLogin(username, password);
         const authData = loginRes["data"];
+        
         if (authData) {
           const { authenticated } = authData;
           if (authenticated) {

--- a/src/login/login.component.tsx
+++ b/src/login/login.component.tsx
@@ -62,7 +62,7 @@ export default function Login(props: LoginProps) {
       try {
         const loginRes = await performLogin(username, password);
         const authData = loginRes["data"];
-        
+
         if (authData) {
           const { authenticated } = authData;
           if (authenticated) {

--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import openmrsRootDecorator from "@openmrs/react-root-decorator";
 import { defineConfigSchema, validators } from "@openmrs/esm-module-config";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { BrowserRouter, Route } from "react-router-dom";
 import Login from "./login/login.component";
 import ChooseLocation from "./choose-location/choose-location.component";
-import { searchLocationsFhir } from "./choose-location/choose-location.resource";
 
 defineConfigSchema("@openmrs/esm-login", {
   chooseLocation: {
@@ -43,35 +41,14 @@ defineConfigSchema("@openmrs/esm-login", {
 });
 
 function Root(props) {
-  const [user, setUser] = React.useState(null);
-  const [loginLocations, setLoginLocations] = React.useState([]);
-
-  React.useEffect(() => {
-    const ac = new AbortController();
-    const sub = searchLocationsFhir("").then(
-      (locations) => setLoginLocations(locations.data.entry),
-      createErrorHandler()
-    );
-    return () => ac.abort();
-  }, []);
-
   return (
     <BrowserRouter basename={window["getOpenmrsSpaBase"]()}>
-      <Route
-        exact
-        path="/login"
-        render={(props) => <Login {...props} loginLocations={loginLocations} />}
-      />
-      <Route
-        exact
-        path="/login/location"
-        render={(props) => (
-          <ChooseLocation {...props} loginLocations={loginLocations} />
-        )}
-      />
+      <Route exact path="/login" component={Login} />
+      <Route exact path="/login/location" component={ChooseLocation} />
     </BrowserRouter>
   );
 }
+
 export default openmrsRootDecorator({
   featureName: "login",
   moduleName: "@openmrs/esm-login",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+export interface LocationResponse {
+  type: string;
+  total: number;
+  resourceType: string;
+  meta: {
+    lastUpdated: string;
+  };
+  link: Array<{
+    relation: string;
+    url: string;
+  }>;
+  id: string;
+  entry: Array<LocationEntry>;
+}
+
+export interface LocationEntry {
+  resource: Resource;
+}
+
+export interface Resource {
+  id: string;
+  name: string;
+  resourceType: string;
+  status: "active" | "inactive";
+  meta?: {
+    tag?: Array<{
+      code: string;
+      display: string;
+      system: string;
+    }>;
+  };
+}

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,0 +1,10 @@
+{
+  "confirm": "Bestätigen",
+  "location": "Einsatzort",
+  "locationNotFound": "Kein Einsatzort gefunden",
+  "login": "Login",
+  "password": "Passwort",
+  "username": "Benutzername",
+  "welcome": "Willkommen",
+  "poweredBy": "Powered by"
+}


### PR DESCRIPTION
With the recent PR we introduced a problem here. While the "classic" API endpoint allows querying locations even when unauthorized, FIHR requires the user to be authenticated.

Therefore, we need to perform these calls *after* the user logged in.

![image](https://user-images.githubusercontent.com/1766191/81837596-5637c900-9545-11ea-9430-2a401ca9aa8b.png)

I also changed it to introduce a small loading stage in between.

**Question**: Do we have design for a loading spinner? Temporarily, I just used "Loading ...", but I would love to replace it with our official version / design. What are we doing in such cases?

Consequently, the logic for redirection is now in just a single component; beforehand it was split in two components (and duplicated). The location picker is also free of API calls, which makes it easier to test.

I also fixed another bug in the location picker, which is using the previous search result for filtering again. So if "foo" was used and now it is changed to "ph" nothing is shown. Now, with the fix "ph" will result in "Pharmacy" (and others) independent of what the previous search result was.

Another small bug was that we used managed radio buttons, but these lost their state when searching. So when you clicked on "Pharmacy", but changed the search to "foo" and back to "ph", nothing was selected even though confirm was still active (and in our state "Pharmacy" was still set).

Sorry for the lengthy PR; I realized all these issues when tackling the AUTH issue with FIHR. I couldn't stop there. My bad! 🦸 