### PR TITLE
Fixed failing FHIR2 endpoint to fhir2/R4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2933,7 +2933,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -4098,15 +4097,26 @@
       }
     },
     "@openmrs/esm-api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@openmrs/esm-api/-/esm-api-1.3.0.tgz",
-      "integrity": "sha512-Fw7pHLNCTiq8gOR7UKDV6Tev+wBsTs+C3SSNlZDciLA+sjbthd4HUZ2c63u7ymlC4n02wX2lgpOolLjlWYnvbw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@openmrs/esm-api/-/esm-api-2.1.0.tgz",
+      "integrity": "sha512-CUMzSKoGWYVfkW3pU+cJgJRIHSl3r+yGOiHvYSq3fje7kvzCRB7F7rBQpcMCsEooS16yrmQnV0zD2LNrTY8Erg==",
       "requires": {
         "@openmrs/esm-error-handling": "^1.1.0",
         "@openmrs/esm-module-config": "^1.1.0",
         "@types/fhir": "0.0.31",
+        "i18next": "^19.4.4",
         "react": "^16.11.0",
         "single-spa": "^4.4.1"
+      },
+      "dependencies": {
+        "i18next": {
+          "version": "19.4.5",
+          "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.4.5.tgz",
+          "integrity": "sha512-aLvSsURoupi3x9IndmV6+m3IGhzLzhYv7Gw+//K3ovdliyGcFRV0I1MuddI0Bk/zR7BG1U+kJOjeHFUcUIdEgg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1"
+          }
+        }
       }
     },
     "@openmrs/esm-error-handling": {
@@ -15578,8 +15588,7 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.4",
@@ -16218,9 +16227,9 @@
       "dev": true
     },
     "single-spa": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/single-spa/-/single-spa-4.4.3.tgz",
-      "integrity": "sha512-xpbCMrA3TtzJkjiq6zwxZQTqBTWtUrq4IDZWT+tOba+FgbFSrvCDCmHhadxDO9fm3JBuyELvKoS8qD73gUIh9Q=="
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/single-spa/-/single-spa-4.4.4.tgz",
+      "integrity": "sha512-0+eiZXHeTbVs7eOaVxOyQbLTRnbabfGT8BkCZ8BFY6CrqozlQebmXf5CS2moQ/xZTAJr0qREo7ggfvycFkLLqA=="
     },
     "single-spa-react": {
       "version": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@openmrs/esm-api": "^1.3.0",
+    "@openmrs/esm-api": "^2.0.0",
     "@openmrs/esm-error-handling": "^1.1.0",
     "@openmrs/esm-module-config": "^1.3.1",
     "@types/react": "^16.9.25",

--- a/src/choose-location/choose-location.resource.ts
+++ b/src/choose-location/choose-location.resource.ts
@@ -1,4 +1,8 @@
-import { openmrsFetch, openmrsObservableFetch } from "@openmrs/esm-api";
+import {
+  openmrsFetch,
+  openmrsObservableFetch,
+  fhirConfig,
+} from "@openmrs/esm-api";
 import { map } from "rxjs/operators";
 import { LocationResponse } from "../types";
 
@@ -26,10 +30,13 @@ export function searchLocationsFhir(
   location: string,
   abortController: AbortController
 ) {
-  return openmrsFetch<LocationResponse>(`/ws/fhir2/Location?name=${location}`, {
-    method: "GET",
-    signal: abortController.signal,
-  });
+  return openmrsFetch<LocationResponse>(
+    `${fhirConfig.baseUrl}/Location?name=${location}`,
+    {
+      method: "GET",
+      signal: abortController.signal,
+    }
+  );
 }
 
 export function queryLocations(


### PR DESCRIPTION
1. Upgrade @openmrs-esm-api dependency to version 2.0.0
2. Fixed the failing fhir2 endpoint to use the latest version R4 