### PR TITLE
Tighten margins on the login page header; fix exhaustive deps warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16842,7 +16842,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/location-picker/location-picker.component.tsx
+++ b/src/location-picker/location-picker.component.tsx
@@ -8,7 +8,7 @@ import styles from "../styles.css";
 
 const CardHeader: React.FC = (props) => (
   <div className={styles["card-header"]}>
-    <h2 className={`omrs-margin-8 omrs-margin-left-12`}>{props.children}</h2>
+    <h3 className={`omrs-margin-8 omrs-margin-left-12`}>{props.children}</h3>
   </div>
 );
 
@@ -178,9 +178,9 @@ const LocationPicker: React.FC<LocationPickerProps> = (props) => {
   return (
     <div className={`canvas ${styles["container"]}`}>
       {!props.hideWelcomeMessage && (
-        <h1 className={styles["welcome-msg"]}>
+        <h2 className={styles["welcome-msg"]}>
           <Trans i18nKey="welcome">Welcome</Trans> {props.currentUser}
-        </h1>
+        </h2>
       )}
       <form onSubmit={handleSubmit}>
         <div className={`${styles["location-card"]} omrs-card`}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -114,4 +114,5 @@
 
 .welcome-msg {
   text-transform: capitalize;
+  margin: 1rem 0;
 }


### PR DESCRIPTION
This PR:

- Adjusts the margins on the login page welcome header, as well as reducing the size of the welcome text and the `Location` heading at the top of the location picker card.
- Also fixes a couple of React hooks exhaustive dependencies warnings that were being flagged on running lint.

Before:
![Screenshot 2020-12-16 at 09 18 12](https://user-images.githubusercontent.com/8509731/102345430-6ec20300-3fae-11eb-8094-e721d1431ee2.png)

After:
![Screenshot 2020-12-16 at 09 16 38](https://user-images.githubusercontent.com/8509731/102345446-77b2d480-3fae-11eb-9c84-6a7531db6878.png)
