### PR TITLE
Append 'slot' to extensionSlots to comply with naming convention

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function setupOpenMRS() {
       },
       {
         id: "location-changer",
-        slot: "user-panel-switcher",
+        slot: "user-panel-slot",
         load: getAsyncLifecycle(
           () => import("./change-location-link/change-location-link.component"),
           options


### PR DESCRIPTION
### What does this PR do?

1. Update slot names to comply with the naming convention on slots