### PR TITLE
Make location picker pageSize  configurable 

### DIFF
--- a/__mocks__/openmrs-esm-framework.mock.tsx
+++ b/__mocks__/openmrs-esm-framework.mock.tsx
@@ -49,6 +49,9 @@ export const config = {
   links: {
     loginSuccess: "${openmrsSpaBase}/home",
   },
+  chooseLocationPagesize: {
+    pageSize: 3,
+  },
 };
 
 export function useConfig() {

--- a/__mocks__/openmrs-esm-framework.mock.tsx
+++ b/__mocks__/openmrs-esm-framework.mock.tsx
@@ -41,6 +41,7 @@ export const openmrsComponentDecorator = jest
 export const config = {
   chooseLocation: {
     enabled: true,
+    numberToShow: 3,
   },
   logo: {
     src: null,
@@ -48,9 +49,6 @@ export const config = {
   },
   links: {
     loginSuccess: "${openmrsSpaBase}/home",
-  },
-  chooseLocationPagesize: {
-    pageSize: 3,
   },
 };
 

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,0 +1,43 @@
+import { validators, Type } from "@openmrs/esm-framework";
+
+export const configSchema = {
+  chooseLocation: {
+    enabled: {
+      _type: Type.Boolean,
+      _default: true,
+      _description:
+        "Whether to show a 'Choose Location' screen after login. " +
+        "If true, the user will be taken to the loginSuccess URL after they " +
+        "choose a location.",
+    },
+  },
+  chooseLocationPagesize: {
+    pageSize: {
+      _type: Type.Number,
+      _default: 8,
+      _description: "The number of locations displayed on location picker",
+    },
+  },
+
+  links: {
+    loginSuccess: {
+      _type: Type.String,
+      _description: "Where to take the user after they are logged in.",
+      _default: "${openmrsSpaBase}/home",
+      _validators: [validators.isUrl],
+    },
+  },
+  logo: {
+    src: {
+      _type: Type.String,
+      _default: null,
+      _description:
+        "A path or URL to an image. Defaults to the OpenMRS SVG sprite.",
+    },
+    alt: {
+      _type: Type.String,
+      _default: "Logo",
+      _description: "Alt text, shown on hover",
+    },
+  },
+};

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -10,9 +10,7 @@ export const configSchema = {
         "If true, the user will be taken to the loginSuccess URL after they " +
         "choose a location.",
     },
-  },
-  chooseLocationPagesize: {
-    pageSize: {
+    numberToShow: {
       _type: Type.Number,
       _default: 8,
       _description: "The number of locations displayed on location picker",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,5 @@
-import {
-  getAsyncLifecycle,
-  defineConfigSchema,
-  validators,
-  Type,
-} from "@openmrs/esm-framework";
+import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
+import { configSchema } from "./config-schema";
 import { backendDependencies } from "./openmrs-backend-dependencies";
 
 const importTranslation = require.context(
@@ -21,39 +17,7 @@ function setupOpenMRS() {
     moduleName,
   };
 
-  defineConfigSchema(moduleName, {
-    chooseLocation: {
-      enabled: {
-        _type: Type.Boolean,
-        _default: true,
-        _description:
-          "Whether to show a 'Choose Location' screen after login. " +
-          "If true, the user will be taken to the loginSuccess URL after they " +
-          "choose a location.",
-      },
-    },
-    links: {
-      loginSuccess: {
-        _type: Type.String,
-        _description: "Where to take the user after they are logged in.",
-        _default: "${openmrsSpaBase}/home",
-        _validators: [validators.isUrl],
-      },
-    },
-    logo: {
-      src: {
-        _type: Type.String,
-        _default: null,
-        _description:
-          "A path or URL to an image. Defaults to the OpenMRS SVG sprite.",
-      },
-      alt: {
-        _type: Type.String,
-        _default: "Logo",
-        _description: "Alt text, shown on hover",
-      },
-    },
-  });
+  defineConfigSchema(moduleName, configSchema);
 
   return {
     lifecycle: getAsyncLifecycle(() => import("./root.component"), options),

--- a/src/location-picker/location-picker.component.scss
+++ b/src/location-picker/location-picker.component.scss
@@ -46,6 +46,7 @@
   padding: 0rem 1.5rem 1.5rem 1.5rem;
   height: 22rem;
   width: 23rem;
+  overflow-y: scroll;
 }
 
 .locationRadioButton {

--- a/src/location-picker/location-picker.component.test.tsx
+++ b/src/location-picker/location-picker.component.test.tsx
@@ -2,7 +2,13 @@ import "@testing-library/jest-dom";
 import React from "react";
 import LocationPicker from "./location-picker.component";
 import { act } from "react-dom/test-utils";
-import { cleanup, fireEvent, render, wait } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  wait,
+  screen,
+} from "@testing-library/react";
 
 const loginLocations = {
   data: {
@@ -195,5 +201,28 @@ describe(`<LocationPicker />`, () => {
       "userDefaultLoginLocationKey",
       "111"
     );
+  });
+
+  it("should display the correct pageSize", async () => {
+    expect(screen.getByText(/Showing 2 of 2 locations/i)).toBeInTheDocument();
+    cleanup();
+    const loginLocations: any = {
+      data: {
+        entry: [
+          { resource: { id: "111", name: "Earth" } },
+          { resource: { id: "222", name: "Mars" } },
+          { resource: { id: "333", name: "Mercury" } },
+        ],
+      },
+    };
+    const wrapper = render(
+      <LocationPicker
+        loginLocations={loginLocations.data.entry}
+        onChangeLocation={onChangeLocation}
+        searchLocations={searchLocations}
+        currentUser=""
+      />
+    );
+    expect(wrapper.getByText(/Showing 3 of 3 locations/i)).toBeInTheDocument();
   });
 });

--- a/src/location-picker/location-picker.component.tsx
+++ b/src/location-picker/location-picker.component.tsx
@@ -32,7 +32,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   currentLocationUuid,
 }) => {
   const config = useConfig();
-  const { chooseLocationPagesize } = config;
+  const { chooseLocation } = config;
   const { t } = useTranslation();
   const userDefaultLoginLocation: string = "userDefaultLoginLocationKey";
   const getDefaultUserLoginLocation = (): string => {
@@ -51,7 +51,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   const [searchTerm, setSearchTerm] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [pageSize, setPageSize] = React.useState<number>(
-    chooseLocationPagesize.pageSize
+    chooseLocation.numberToShow
   );
   const inputRef = React.useRef();
 
@@ -155,7 +155,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   React.useEffect(() => {
     locationData.locationResult.length < pageSize
       ? setPageSize(locationData.locationResult.length)
-      : setPageSize(chooseLocationPagesize.pageSize);
+      : setPageSize(chooseLocation.numberToShow);
   }, [locationData.locationResult.length]);
 
   return (

--- a/src/location-picker/location-picker.component.tsx
+++ b/src/location-picker/location-picker.component.tsx
@@ -5,7 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { LocationEntry } from "../types";
 import styles from "./location-picker.component.scss";
 import Search from "carbon-components-react/es/components/Search";
-import { createErrorHandler } from "@openmrs/esm-framework";
+import { createErrorHandler, useConfig } from "@openmrs/esm-framework";
 import RadioButtonGroup from "carbon-components-react/es/components/RadioButtonGroup";
 import RadioButton from "carbon-components-react/es/components/RadioButton";
 import Button from "carbon-components-react/es/components/Button";
@@ -31,7 +31,8 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   hideWelcomeMessage,
   currentLocationUuid,
 }) => {
-  const pageSize = 8;
+  const config = useConfig();
+  const { chooseLocationPagesize } = config;
   const { t } = useTranslation();
   const userDefaultLoginLocation: string = "userDefaultLoginLocationKey";
   const getDefaultUserLoginLocation = (): string => {
@@ -49,6 +50,9 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   });
   const [searchTerm, setSearchTerm] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [pageSize, setPageSize] = React.useState<number>(
+    chooseLocationPagesize.pageSize
+  );
   const inputRef = React.useRef();
 
   const searchTimeout = 300;
@@ -147,6 +151,12 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
       locationResult: prevState.locationResult,
     }));
   };
+
+  React.useEffect(() => {
+    locationData.locationResult.length < pageSize
+      ? setPageSize(locationData.locationResult.length)
+      : setPageSize(chooseLocationPagesize.pageSize);
+  }, [locationData.locationResult.length]);
 
   return (
     <div className={styles["locationPickerContainer"]}>


### PR DESCRIPTION
### What does this PR do?

1. Makes the location-picker page size configurable
2. Display the correct number of locations when less than the default


### Screenshoot
![screencast 2021-03-11 01-00-17](https://user-images.githubusercontent.com/28008754/110704489-1180cb00-8206-11eb-82b7-cad43eb1f3f3.gif)
