### PR TITLE
Small improvements to the location picker

### DIFF
--- a/src/location-picker/location-picker.component.test.tsx
+++ b/src/location-picker/location-picker.component.test.tsx
@@ -170,12 +170,12 @@ describe(`<LocationPicker />`, () => {
     expect(locationRadioButton).toHaveProperty("checked", false);
   });
 
-  it("shows no location found", async () => {
+  it("shows error message when no matching locations can be found", async () => {
     fireEvent.change(searchInput, { target: { value: "doof" } });
 
     await wait(() => {
       expect(
-        wrapper.getByText("Sorry, no location has been found")
+        wrapper.getByText("Sorry, no matching location was found")
       ).not.toBeNull();
     });
     expect(submitButton).toHaveAttribute("disabled");

--- a/src/location-picker/location-picker.component.tsx
+++ b/src/location-picker/location-picker.component.tsx
@@ -187,9 +187,9 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
             <p>
               {searchTerm
                 ? `${locationData.locationResult.length} ${
-                    locationData.locationResult.length > 1
-                      ? t("matches", "matches")
-                      : t("match", "match")
+                    locationData.locationResult.length === 1
+                      ? t("match", "match")
+                      : t("matches", "matches")
                   } ${t("found", "found")}`
                 : `${t("showing", "Showing")} ${pageSize} ${t("of", "of")} ${
                     locationData.locationResult.length
@@ -220,7 +220,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
             {locationData.locationResult.length === 0 && (
               <p className={styles["locationNotFound"]}>
                 <Trans i18nKey="locationNotFound">
-                  Sorry, no location has been found
+                  Sorry, no matching location was found
                 </Trans>
               </p>
             )}

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,7 +1,7 @@
 {
   "confirm": "Confirm",
   "location": "Location",
-  "locationNotFound": "Sorry, no location has been found",
+  "locationNotFound": "Sorry, no matching location was found",
   "login": "Log in",
   "password": "Password",
   "username": "Username",


### PR DESCRIPTION
These include:

- Pluralizing the `n match(es) found` text after doing a search when the number of search results is either `0` or `greater than 1`.
- Changing the error message displayed when no matching search results can be found.


<img width="371" alt="Screenshot 2021-03-17 at 16 20 41" src="https://user-images.githubusercontent.com/8509731/111474079-ba668300-873c-11eb-8458-731a2fac2736.png">
