### PR TITLE
Small improvement on location picker margin

### DIFF
--- a/src/location-picker/location-picker.component.scss
+++ b/src/location-picker/location-picker.component.scss
@@ -44,7 +44,7 @@
   display: flex;
   background-color: $ui-01;
   padding: 0rem 1.5rem 1.5rem 1.5rem;
-  height: 22rem;
+  height: 23.5rem;
   width: 23rem;
   overflow-y: scroll;
 }


### PR DESCRIPTION
### What does the PR do?

At the moment the last option on the location picker is not displaying correctly
<img width="383" alt="Screenshot 2021-03-19 at 12 38 36" src="https://user-images.githubusercontent.com/28008754/111761050-7d230200-88b0-11eb-89f5-8d28d38f70a7.png">

This PR fixes this error